### PR TITLE
switch to cross-platform short -P parameter

### DIFF
--- a/featherpad/featherpad.pro
+++ b/featherpad/featherpad.pro
@@ -95,7 +95,7 @@ unix {
 
   # add the fpad symlink
   slink.path = $$BINDIR
-  slink.extra += ln -sf $${TARGET} fpad && cp --no-dereference fpad $(INSTALL_ROOT)$$BINDIR
+  slink.extra += ln -sf $${TARGET} fpad && cp -P fpad $(INSTALL_ROOT)$$BINDIR
 
   desktop.path = $$DATADIR/applications
   desktop.files += ./data/$${TARGET}.desktop


### PR DESCRIPTION
cross-platform compatibility tweak: `--no-dereference` parameter is GNU `cp` specific alias for `-P` and isn’t present on systems like FreeBSD