### PR TITLE
Fix some typos

### DIFF
--- a/featherpad/config.h
+++ b/featherpad/config.h
@@ -329,14 +329,14 @@ public:
     bool getExecuteScripts() const {
         return executeScripts_;
     }
-    void setExecuteScripts (bool excute) {
-        executeScripts_ = excute;
+    void setExecuteScripts (bool execute) {
+        executeScripts_ = execute;
     }
     QString getExecuteCommand() const {
         return executeCommand_;
     }
-    void setExecuteCommand (const QString& commnad) {
-        executeCommand_ = commnad;
+    void setExecuteCommand (const QString& command) {
+        executeCommand_ = command;
     }
 /*************************/
     bool getAppendEmptyLine() const {

--- a/featherpad/data/help
+++ b/featherpad/data/help
@@ -16,7 +16,7 @@ If there is more that one tab, each one will have a right-click menu for closing
 
 If a file is opened in a tab, the right-click menu of that tab will also contain two items for copying the name and path of the file.
 
-For users' comfort, double clicking on an empty area of tha tab-bar creates a new tab.
+For users' comfort, double clicking on an empty area of the tab-bar creates a new tab.
 
 ***********************
 *   File Management   *
@@ -56,7 +56,7 @@ The programming language is detected based on the mime type or file name and its
 
 If the text has no programming language or its syntax is not supported, only its hyperlinks/URLs will be highlighted and it will be possible to open them by right clicking them and activating the related menu-item or by pressing the Control key, moving the cursor over them, and clicking them while the cursor is like a pointing hand.
 
-Also, there is an optiion in the Preferences dialog that, if enabled and checked, will add a language button to the status bar for overriding the original syntax or lack of it. Reloading a document restores its original syntax.
+Also, there is an option in the Preferences dialog that, if enabled and checked, will add a language button to the status bar for overriding the original syntax or lack of it. Reloading a document restores its original syntax.
 
 There are also options for showing whitespaces (spaces, line ends and the document end) and vertical position lines when syntax highlighting is enabled (by default or temporarily).
 
@@ -71,7 +71,7 @@ To remove the yellow highlights after finishing a search, you could
 * Empty the search entry and press Enter or F3 in it, or
 * Hide the search bar by focusing it and then, pressing Ctrl+F.
 
-The 'Replace' docked window respects the settings for 'Match Case' and 'Whole Word' on the search bar. It can be detached from and reattached to the the main window at top or bottom. To remove the green highlights after replacing text, you could either hide/close the 'Replace' docked window or do as in the case of removing yellow search highlights (without closing the dock).
+The 'Replace' docked window respects the settings for 'Match Case' and 'Whole Word' on the search bar. It can be detached from and reattached to the main window at top or bottom. To remove the green highlights after replacing text, you could either hide/close the 'Replace' docked window or do as in the case of removing yellow search highlights (without closing the dock).
 
 ***********************
 *   Going to A Line   *

--- a/featherpad/highlighter.cpp
+++ b/featherpad/highlighter.cpp
@@ -1304,7 +1304,7 @@ void Highlighter::pythonMLComment (const QString &text, const int indx)
     noteFormat.setFontItalic (true);
     noteFormat.setForeground (DarkRed);
 
-    /* we reset tha block state because this method is also called
+    /* we reset the block state because this method is also called
        during the multiline quotation formatting after clearing formats */
     setCurrentBlockState (-1);
 
@@ -1492,7 +1492,7 @@ int Highlighter::cssHighlighter (const QString &text, bool mainFormatting, const
         if (hugeText)
             setFormat (index, text.length() - index, translucentFormat);
         int endIndex;
-        /* when the css block starts in the prvious line
+        /* when the css block starts in the previous line
            and the search for its end has just begun... */
         if ((prevState == cssBlockState
              || prevState == commentInCssState
@@ -1721,7 +1721,7 @@ void Highlighter::singleLineComment (const QString &text, const int start)
                 }
                 /* take care of next-line comments with languages, for which
                    no highlighting function is called after singleLineComment()
-                   and before the main formaatting in highlightBlock()
+                   and before the main formatting in highlightBlock()
                    (only c and c++ for now) */
                 if ((progLan == "c" || progLan == "cpp")
                     && text.endsWith (QLatin1Char('\\')))
@@ -2114,7 +2114,7 @@ void Highlighter::multiLineQuote (const QString &text, const int start, int comS
                 }
             }
             else if (progLan == "markdown")
-            { // this is the main differenct of a markdown inline code from a single-line quote
+            { // this is the main different of a markdown inline code from a single-line quote
                 isQuotation = false;
             }
         }

--- a/featherpad/singleton.cpp
+++ b/featherpad/singleton.cpp
@@ -71,7 +71,7 @@ FPsingleton::FPsingleton (int &argc, char **argv) : QApplication (argc, argv)
     lockFile_ = new QLockFile (lockFilePath);
 
     if (lockFile_->tryLock())
-    { // create a local server and listen to incomming messages from other instances
+    { // create a local server and listen to incoming messages from other instances
         localServer = new QLocalServer (this);
         connect (localServer, &QLocalServer::newConnection, this, &FPsingleton::receiveMessage);
         if (!localServer->listen (uniqueKey_))

--- a/featherpad/textedit.cpp
+++ b/featherpad/textedit.cpp
@@ -442,7 +442,7 @@ void TextEdit::keyPressEvent (QKeyEvent *event)
             else if (!isReadOnly() && event->key() == Qt::Key_Z)
             {
                 /* QWidgetTextControl::undo() callls ensureCursorVisible() even when there's nothing to undo.
-                   Users may press Ctrl+Z just to know whether a documnet is in its original state and
+                   Users may press Ctrl+Z just to know whether a document is in its original state and
                    a scroll jump can confuse them when there's nothing to undo. */
                 if (!document()->isUndoAvailable())
                 {
@@ -457,7 +457,7 @@ void TextEdit::keyPressEvent (QKeyEvent *event)
         {
             if (highlighter_)
                 viewport()->setCursor (Qt::IBeamCursor);
-            /* QWidgetTextControl::redo() callls ensureCursorVisible() even when there's nothing to redo.
+            /* QWidgetTextControl::redo() calls ensureCursorVisible() even when there's nothing to redo.
                That may cause a scroll jump, which can be confusing when nothing else has happened. */
             if (!isReadOnly() && (event->modifiers() & Qt::ShiftModifier) && event->key() == Qt::Key_Z
                 && !document()->isRedoAvailable())
@@ -960,7 +960,7 @@ void TextEdit::wheelEvent (QWheelEvent *event)
             int fps = qMax (SCROLL_FRAMES_PER_SEC / wheelEvents.size(), 5);
 
             /* set the data for inertial scrolling */
-            scollData data;
+            scrollData data;
             data.delta = delta;
             data.totalSteps = data.leftSteps = fps * SCROLL_DURATION / 1000;
             queuedScrollSteps_.append (data);
@@ -980,7 +980,7 @@ void TextEdit::scrollWithInertia()
     if (!wheelEvent_ || !verticalScrollBar()) return;
 
     int totalDelta = 0;
-    for (QList<scollData>::iterator it = queuedScrollSteps_.begin(); it != queuedScrollSteps_.end(); ++it)
+    for (QList<scrollData>::iterator it = queuedScrollSteps_.begin(); it != queuedScrollSteps_.end(); ++it)
     {
         totalDelta += qRound (static_cast<qreal>(it->delta) / static_cast<qreal>(it->totalSteps));
         -- it->leftSteps;

--- a/featherpad/textedit.h
+++ b/featherpad/textedit.h
@@ -303,7 +303,7 @@ private:
     qint64 size_; // file size for limiting syntax highlighting (the file may be removed)
     QDateTime lastModified_; // the last modification time for knowing about changes.
     int wordNumber_; // the calculated number of words (-1 if not counted yet)
-    QString searchedText_; // the text that is being searched in the documnet
+    QString searchedText_; // the text that is being searched in the document
     QString replaceTitle_; // the title of the Replacement dock (can change)
     QString fileName_; // opened file
     QString prog_; // real programming language (never empty; defaults to "url")
@@ -324,14 +324,14 @@ private:
      ***** Inertial scrolling *****
      ******************************/
     bool inertialScrolling_;
-    struct scollData {
+    struct scrollData {
       int delta;
       int leftSteps;
       int totalSteps;
     };
     QTimer *scrollTimer_;
     QWheelEvent *wheelEvent_;
-    QList<scollData> queuedScrollSteps_;
+    QList<scrollData> queuedScrollSteps_;
 };
 /*************************/
 class LineNumberArea : public QWidget

--- a/featherpad/x11.cpp
+++ b/featherpad/x11.cpp
@@ -32,7 +32,7 @@ namespace FeatherPad {
  *** because Qt does not fetch enough information on X11. ***
  *************************************************************/
 
-// Get the curent virtual desktop.
+// Get the current virtual desktop.
 long fromDesktop()
 {
     long res = -1;


### PR DESCRIPTION
This PR fixes some typos in comments and variable names found by `codespell`.

I've identified two additional typos in `fp.ui` (`chineese` and `curent`) that also have an effect on the translation files - I haven't fixed them, because I don't know how Weblate will react...