### PR TITLE
Added some keywords and Action new-window

### DIFF
--- a/featherpad/data/featherpad.desktop
+++ b/featherpad/data/featherpad.desktop
@@ -22,4 +22,11 @@ Terminal=false
 Type=Application
 MimeType=text/plain;
 Categories=Qt;Utility;TextEditor;
-X-KDE-StartupNotify=false
+X-KDE-StartupNotify=false;
+Keywords=Text;Editor;Plaintext;
+Actions=new-window;
+
+[Desktop Action new-window]
+Name=New Window
+Name[de]=Neues Fenster
+Exec=featherpad --win


### PR DESCRIPTION
* The keywords prevent checkers like lintian to complain about missing keywords
* Action new-window open a new window instead a new tab - works from quickstart
  docks and should work from LXQt-menu too, if we fix the left=right-click mess.