### PR TITLE
Mac OS support

### DIFF
--- a/featherpad/featherpad.pro
+++ b/featherpad/featherpad.pro
@@ -4,7 +4,7 @@ QT += core gui \
       network \
       svg
 
-haiku {
+haiku|macx {
   TARGET = FeatherPad
 }
 else {
@@ -93,7 +93,7 @@ unix {
   }
 }
 
-unix:!haiku {
+unix:!haiku:!macx {
   #VARIABLES
   isEmpty(PREFIX) {
     PREFIX = /usr
@@ -143,5 +143,28 @@ else:haiku {
 
   trans.path = $$PREFIX
   trans.files += data/translations/translations
+  INSTALLS += target help trans
+}
+else:macx{
+  #VARIABLES
+  isEmpty(PREFIX) {
+    PREFIX = /Applications/
+  }
+  BINDIR = $$PREFIX
+  DATADIR = "$$BINDIR/$$TARGET".app
+
+  DEFINES += DATADIR=\\\"$$DATADIR\\\" PKGDATADIR=\\\"$$PKGDATADIR\\\"
+
+  #MAKE INSTALL
+
+  target.path =$$BINDIR
+
+  help.path = $$DATADIR/featherpad
+  help.files += ./data/help
+  help.files += ./data/help_*
+
+  trans.path = $$DATADIR/featherpad
+  trans.files += data/translations/translations
+
   INSTALLS += target help trans
 }

--- a/featherpad/main.cpp
+++ b/featherpad/main.cpp
@@ -101,7 +101,7 @@ int main (int argc, char **argv)
 #ifdef Q_OS_HAIKU
     FPTranslator.load ("featherpad_" + lang, "/translations");
 #else
-    FPTranslator.load ("featherpad_" + lang, DATADIR "/featherpad/translations");
+    FPTranslator.load ("featherpad_" + lang, QStringLiteral (DATADIR) + "/featherpad/translations");
 #endif
     singleton.installTranslator (&FPTranslator);
 


### PR DESCRIPTION
This PR fixes _make install_
Everything works, including
1. Translations (with issues)
2. Docs
3. Settings, window position saving
4. Syntax highligh


Known issues:
1. Shortcuts are displayed incorrectly in settings. For example ctrl+S instead of command+S. However, cmd+S invokes save dialog properly so it's not much a problem.
<img width="812" alt="image" src="https://user-images.githubusercontent.com/19782228/50560078-6a937100-0d16-11e9-9a8a-ca51b189063d.png">
2. Languages are not loaded correctly as the code

` lang = langs.first().split (QLatin1Char ('-')).first(); `

is an awful dirty hack. I do not know if it is okay on Linux, but it actually causes bugs on Mac and other platforms as it reports ru_RU instead of ru-RU so the string is not split and it looks for featherpad_ru_RU.qm that is not found.
3. App icon is okay on dashboard, but not okay in the package list. I will try to fix that later.
<img width="882" alt="image" src="https://user-images.githubusercontent.com/19782228/50560149-497f5000-0d17-11e9-8c6b-a5ae897e7177.png">
P. S. It is my first try in combining qmake and Mac, so some things can be really dirty