### PR TITLE
Add support for the Hurd

### DIFF
--- a/featherpad/singleton.cpp
+++ b/featherpad/singleton.cpp
@@ -23,12 +23,12 @@
 #include <QStandardPaths>
 #include <QCryptographicHash>
 
-#if defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD
+#if defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD || defined Q_OS_HURD
 #include <unistd.h> // for geteuid()
 #endif
 
 #ifdef HAS_X11
-#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD
+#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD || defined Q_OS_HURD
 #include <QX11Info>
 #endif
 #endif
@@ -45,7 +45,7 @@ FPsingleton::FPsingleton (int &argc, char **argv) : QApplication (argc, argv)
 {
 #ifdef HAS_X11
     // For now, the lack of x11 is seen as wayland.
-#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD
+#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD || defined Q_OS_HURD
     isX11_ = QX11Info::isPlatformX11();
 #else
     isX11_ = false;
@@ -262,7 +262,7 @@ FPwin* FPsingleton::newWin (const QStringList& filesList,
     fp->show();
     if (socketFailure_)
         fp->showCrashWarning();
-#if defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD
+#if defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD || defined Q_OS_HURD
     else if (geteuid() == 0)
         fp->showRootWarning();
 #endif

--- a/featherpad/x11.cpp
+++ b/featherpad/x11.cpp
@@ -20,7 +20,7 @@
 #include <QString>
 #include "x11.h"
 
-#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD
+#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD || defined Q_OS_HURD
 #include <X11/Xatom.h>
 #include <QX11Info>
 #endif
@@ -37,7 +37,7 @@ long fromDesktop()
 {
     long res = -1;
 
-#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD
+#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD || defined Q_OS_HURD
     Display  *disp = QX11Info::display();
     if (!disp) return res;
 
@@ -72,7 +72,7 @@ long onWhichDesktop (Window window)
 {
     long res = -1;
 
-#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD
+#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD || defined Q_OS_HURD
     Display *disp = QX11Info::display();
     if (!disp) return res;
 
@@ -107,7 +107,7 @@ long onWhichDesktop (Window window)
 
 bool isWindowShaded (Window window)
 {
-#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD
+#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD || defined Q_OS_HURD
     Display *disp = QX11Info::display();
     if (!disp) return false;
 
@@ -142,7 +142,7 @@ bool isWindowShaded (Window window)
 /*************************/
 void unshadeWindow (Window window)
 {
-#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD
+#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD || defined Q_OS_HURD
     Display *disp = QX11Info::display();
     if (!disp) return;
 

--- a/featherpad/x11.h
+++ b/featherpad/x11.h
@@ -20,7 +20,7 @@
 #ifndef X11_H
 #define X11_H
 
-#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD
+#if defined Q_WS_X11 || defined Q_OS_LINUX || defined Q_OS_FREEBSD || defined Q_OS_OPENBSD || defined Q_OS_HURD
 #include <X11/Xlib.h>
 #endif
 


### PR DESCRIPTION
The commit just uses the Linux/BSD code also in the HURD case.

I have searched for lines containing `Q_OS_` and modified lines containing `Q_OS_LINUX`.

I have tested:
- Open a file, edit it and save it at another location.
- Whether a warning is shown when running as root.

This should not affect operating systems other than GNU Hurd

Should fix issue #290