### PR TITLE
Handle haxe language files as JS to get syntax highlighting

### DIFF
--- a/featherpad/syntax.cpp
+++ b/featherpad/syntax.cpp
@@ -114,7 +114,7 @@ void FPwin::setProgLang (TextEdit *textEdit)
                  || baseName == "mimeinfo.cache" || baseName == "mimeapps.list" || baseName.endsWith ("-mimeapps.list")
                  || fname.endsWith (".pls", Qt::CaseInsensitive))
              progLan = "config";
-        else if (fname.endsWith (".js"))
+        else if (fname.endsWith (".js") || fname.endsWith (".hx"))
             progLan = "javascript";
         else if (fname.endsWith (".qml"))
             progLan = "qml";


### PR DESCRIPTION
Hello,

I was to create an Issue to have syntax highlighting in **haxe** language.
The **JS** highlighting works fine for **haxe** language, therefore here is a _hacky_ proposal which worked for me.

If you could detail the proper steps I can remake the pull request.

Regards