### PR TITLE
Feature: Selection Highlight

### DIFF
--- a/featherpad/searchbar.cpp
+++ b/featherpad/searchbar.cpp
@@ -269,4 +269,9 @@ void SearchBar::updateShortcuts (bool disable)
     }
 }
 
+void SearchBar::requestForSearch(QString text)
+{
+	lineEdit_->setText(text);
+}
+
 }

--- a/featherpad/searchbar.h
+++ b/featherpad/searchbar.h
@@ -78,6 +78,7 @@ public:
     bool matchRegex() const;
 
     void updateShortcuts (bool disable);
+    void requestForSearch(QString text);
 
 signals:
     void searchFlagChanged();

--- a/featherpad/tabpage.cpp
+++ b/featherpad/tabpage.cpp
@@ -39,6 +39,9 @@ TabPage::TabPage (int bgColorValue,
 
     connect (searchBar_, &SearchBar::find, this, &TabPage::find);
     connect (searchBar_, &SearchBar::searchFlagChanged, this, &TabPage::searchFlagChanged);
+
+    connect (textEdit_, &TextEdit::triggerHighlight, searchBar_, &SearchBar::requestForSearch);
+
 }
 /*************************/
 void TabPage::setSearchBarVisible (bool visible)

--- a/featherpad/textedit.cpp
+++ b/featherpad/textedit.cpp
@@ -1921,6 +1921,10 @@ void TextEdit::onSelectionChanged()
     {
         prevAnchor = cur.anchor();
         prevPos = cur.position();
+
+        if (qApp->keyboardModifiers() & Qt::ControlModifier) {
+			emit triggerHighlight(cur.selectedText());
+        }
     }
 }
 /*************************/

--- a/featherpad/textedit.h
+++ b/featherpad/textedit.h
@@ -249,6 +249,7 @@ signals:
     void updateRect (const QRect &rect, int dy);
     void zoomedOut (TextEdit *textEdit); // needed for reformatting text
     void updateBracketMatching();
+    void triggerHighlight(QString text);
 
 public slots:
     void copy();


### PR DESCRIPTION
I was missing the feature that some editors have(kate) to select a portion of text and the matches in the rest of the document are highlighted.

- As _highlighting matches_ is already implemented, I tried that by emulating a search iteration upon textedit::onSelectionChanged. 
   - That has failed when emmitting back from Searchbar::findForward the find signal. I bet because find handling is performing selection changes, then we enter in a deadly loop.

- Therefore  this PR is staying somewhere in the middle with a less agressive and simple approach. 
    - If there is a selection with the CTRL modifier key performed, the text selected is going to be copied to the SearchBar LineEdit element. Then is up to the user to press F3/F4 to search and highlight.

The whole intention is to ease the typical combination:
- SELECT/COPY/FIND/PASTE/NEXT,NEXT,NEXT.... 

which gets simplified to
- SELECT/NEXT,NEXT,NEXT....
