### PR TITLE
Update featherpad_de.ts

### DIFF
--- a/featherpad/data/translations/featherpad_de.ts
+++ b/featherpad/data/translations/featherpad_de.ts
@@ -2422,7 +2422,7 @@ in die gespeicherte Sitzung eingeschlossen.</translation>
     <message>
         <location filename="../../textedit.cpp" line="178"/>
         <source>Double click to center current line</source>
-        <translation>Doppel-Klick um die aktuelle Zeile zu zentreieren</translation>
+        <translation>Doppel-Klick um die aktuelle Zeile zu zentrieren</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Typo: zentreieren => zentrieren