### PR TITLE
Fix hunspell include paths

### DIFF
--- a/featherpad/featherpad.pro
+++ b/featherpad/featherpad.pro
@@ -121,7 +121,8 @@ else:unix:!macx:!haiku:!os2 {
 }
 
 unix {
-  LIBS += -lhunspell
+  CONFIG += link_pkgconfig
+  PKGCONFIG += hunspell
   #TRANSLATIONS
   exists($$[QT_INSTALL_BINS]/lrelease) {
     TRANSLATIONS = $$system("find data/translations/ -name 'featherpad_*.ts'")

--- a/featherpad/spellChecker.cpp
+++ b/featherpad/spellChecker.cpp
@@ -24,7 +24,7 @@
 #include <QStringList>
 #include <QRegularExpression>
 
-#include <hunspell/hunspell.hxx>
+#include <hunspell.hxx>
 
 namespace FeatherPad {
 


### PR DESCRIPTION
Check `pkg-config --cflags hunspell`
It ALWAYS returns path to hunspell dir
https://github.com/hunspell/hunspell/blob/31e6d6323026a3bef12c5912ce032d88bfef2091/hunspell.pc.in#L10
That's why it's always correct to include "hunspell.hxx" file instead of "hunspell/hunspell.hxx" on any OS
HUNSPELL_INCLUDE_DIRS is set to pkg-config param, so it's also always correct.
I didn't test the qmake solution, but since it is supposed to take the path from pkgconfig, it should work fine as well.