### PR TITLE
Add configurable ability to always open files in one window on X11

### DIFF
--- a/featherpad/config.cpp
+++ b/featherpad/config.cpp
@@ -109,6 +109,7 @@ Config::Config():
     appendEmptyLine_ (true),
     removeTrailingSpaces_ (false),
     openInWindows_ (false),
+    openInWindowsIfMinimized_ (true),
     nativeDialog_ (true),
     inertialScrolling_ (false),
     autoSave_ (false),
@@ -225,6 +226,10 @@ void Config::readConfig()
 
     if (settings.value ("openInWindows").toBool())
         openInWindows_ = true; // false by default
+
+    v = settings.value ("openInWindowsIfMinimized");
+    if (v.isValid()) // true by default
+        openInWindowsIfMinimized_ = v.toBool();
 
     v = settings.value ("nativeDialog");
     if (v.isValid()) // true by default
@@ -512,6 +517,7 @@ void Config::writeConfig()
     settings.setValue ("tabWrapAround", tabWrapAround_);
     settings.setValue ("hideSingleTab", hideSingleTab_);
     settings.setValue ("openInWindows", openInWindows_);
+    settings.setValue ("openInWindowsIfMinimized", openInWindowsIfMinimized_);
     settings.setValue ("nativeDialog", nativeDialog_);
     settings.setValue ("closeWithLastTab", closeWithLastTab_);
     settings.setValue ("sharedSearchHistory", sharedSearchHistory_);

--- a/featherpad/config.h
+++ b/featherpad/config.h
@@ -398,6 +398,13 @@ public:
         openInWindows_ = windows;
     }
 
+    bool getOpenInWindowsIfMinimized() const {
+        return openInWindowsIfMinimized_;
+    }
+    void setOpenInWindowsIfMinimized (bool windows) {
+        openInWindowsIfMinimized_ = windows;
+    }
+
     bool getNativeDialog() const {
         return nativeDialog_;
     }
@@ -626,6 +633,7 @@ private:
          appendEmptyLine_,
          removeTrailingSpaces_,
          openInWindows_,
+         openInWindowsIfMinimized_,
          nativeDialog_,
          inertialScrolling_,
          autoSave_,

--- a/featherpad/singleton.cpp
+++ b/featherpad/singleton.cpp
@@ -343,7 +343,7 @@ void FPsingleton::handleInfo (const QStringList &info)
                      /* if a window is created a moment ago, it should be
                         on the current desktop but may not report that yet */
                      || whichDesktop == -1)
-                    && (!thisWin->isMinimized() || isWindowShaded (id)))
+                    && (!config_.getOpenInWindowsIfMinimized() || !thisWin->isMinimized() || isWindowShaded (id))) 
 #endif
                )
             {


### PR DESCRIPTION
Add ability to always open files in one window on X11 as it is done on all other platforms.
This way it's more convenient for me and some other users.
Default behavior is unchanged.

I did not add a switch to GUI because this option is platform-specific, but it can be set through config file.
Perhaps it would be even better to make this option work on all platforms, add it to GUI and change default value to `false`.