### PR TITLE
Text option string update

### DIFF
--- a/featherpad/data/translations/featherpad.ts
+++ b/featherpad/data/translations/featherpad.ts
@@ -1535,7 +1535,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_ar_DZ.ts
+++ b/featherpad/data/translations/featherpad_ar_DZ.ts
@@ -1540,7 +1540,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation></translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_bg.ts
+++ b/featherpad/data/translations/featherpad_bg.ts
@@ -1557,7 +1557,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Показване на края на ред и документ</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_ca.ts
+++ b/featherpad/data/translations/featherpad_ca.ts
@@ -1566,7 +1566,7 @@ el tipus de lletra de l&apos;editor té un ample fix (com Monospace).</translati
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Mostra també els finals de línia i de document</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_cs.ts
+++ b/featherpad/data/translations/featherpad_cs.ts
@@ -1563,7 +1563,7 @@ písmo editoru má pevné pitch (jako Monospace).</translation>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Také zobrazovat konce čáry a dokumentu</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_cy.ts
+++ b/featherpad/data/translations/featherpad_cy.ts
@@ -1539,7 +1539,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation></translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_da.ts
+++ b/featherpad/data/translations/featherpad_da.ts
@@ -1560,7 +1560,7 @@ skrifttype har en fast tegnbredde (såsom Monospace).</translation>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Vis også linje- og dokumentslutninger</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_de.ts
+++ b/featherpad/data/translations/featherpad_de.ts
@@ -1561,7 +1561,7 @@ mit einem festen Abstand (wie Monospace) gezeichnet.</translation>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Auch Zeilen- und Dokumentende anzeigen</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_el.ts
+++ b/featherpad/data/translations/featherpad_el.ts
@@ -1555,7 +1555,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Να εμφανίζονται επίσης τα πέρατα γραμμής και εγγράφου</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_eo.ts
+++ b/featherpad/data/translations/featherpad_eo.ts
@@ -1562,7 +1562,7 @@ la redaktila tiparo havus fiksitan larĝon (kiel Monospace).</translation>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Ankaŭ montru la liniajn kaj dokumentan finojn</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_es.ts
+++ b/featherpad/data/translations/featherpad_es.ts
@@ -1567,7 +1567,7 @@ si el tipo de fuente utilizado es de ancho fijo.</translation>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Mostrar símbolos en los saltos de linea y el final del documento</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_et.ts
+++ b/featherpad/data/translations/featherpad_et.ts
@@ -1561,7 +1561,7 @@ kirjatüübiks määranud fikseeritud laiusega fondi (nagu näiteks Monospace).<
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Näita rea ja faili lõpumärke</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_fa.ts
+++ b/featherpad/data/translations/featherpad_fa.ts
@@ -1551,7 +1551,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>همچنين نمايش پايان هر خط و کل سند</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_fi.ts
+++ b/featherpad/data/translations/featherpad_fi.ts
@@ -1561,7 +1561,7 @@ käytössä on tasalevyinen kirjasin (kuten Monospace).</translation>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Näytä myös rivien sekä asiakirjan loput</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_fr.ts
+++ b/featherpad/data/translations/featherpad_fr.ts
@@ -1563,7 +1563,7 @@ uniquement si la police a une taille constante (comme Monospace).</translation>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Afficher également la fin de ligne et de document</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_he.ts
+++ b/featherpad/data/translations/featherpad_he.ts
@@ -1560,7 +1560,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>להציג גם סיומות שורה ומסמך</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_hi.ts
+++ b/featherpad/data/translations/featherpad_hi.ts
@@ -1537,7 +1537,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_hr.ts
+++ b/featherpad/data/translations/featherpad_hr.ts
@@ -1537,7 +1537,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_hu.ts
+++ b/featherpad/data/translations/featherpad_hu.ts
@@ -1558,7 +1558,7 @@ a betűtípus rögzített szélességű (pl. Monospace).</translation>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Sorvégek és dokumentumvég megjelenítése</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_id.ts
+++ b/featherpad/data/translations/featherpad_id.ts
@@ -1539,7 +1539,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation></translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_it.ts
+++ b/featherpad/data/translations/featherpad_it.ts
@@ -1563,7 +1563,7 @@ se il font dell&amp;#39;editor è di larghezza fissa (come Monospace).</translat
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Mostra anche la fine della riga e del documento</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_ja.ts
+++ b/featherpad/data/translations/featherpad_ja.ts
@@ -1602,7 +1602,7 @@ when the syntax is highlighted.</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>行末と文書の末尾を示すマークを表示する</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_ko.ts
+++ b/featherpad/data/translations/featherpad_ko.ts
@@ -1563,7 +1563,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>줄과 문서 끝도 표시</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_lt.ts
+++ b/featherpad/data/translations/featherpad_lt.ts
@@ -1561,7 +1561,7 @@ jei redaktoriaus šriftas yra fiksuoto dydžio (pvz., Lygiaplotis).</translation
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Taip pat rodyti eilučių ir dokumentų pabaigas</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_nb_NO.ts
+++ b/featherpad/data/translations/featherpad_nb_NO.ts
@@ -1558,7 +1558,7 @@ editorens skrift har fast tegnbredde (som Monospace).</translation>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Vis også linje- og dokumentslutt</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_nl.ts
+++ b/featherpad/data/translations/featherpad_nl.ts
@@ -1561,7 +1561,7 @@ het lettertype een vastebreedtelettertype is, zoals Monospace.</translation>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Regel- en documenteinden aangeven</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_pl.ts
+++ b/featherpad/data/translations/featherpad_pl.ts
@@ -1562,7 +1562,7 @@ używasz czcionki o stałej szerokości znaków.</translation>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Pokazuj także koniec dokumentów i wierszy</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_pt.ts
+++ b/featherpad/data/translations/featherpad_pt.ts
@@ -1560,7 +1560,7 @@ o tipo de letra do editor tem um tom fixo (como Monospace).</translation>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Também mostra as extremidades da linha e do documento</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_pt_BR.ts
+++ b/featherpad/data/translations/featherpad_pt_BR.ts
@@ -1558,7 +1558,7 @@ a fonte do editor tiver um passo fixo (como o Monospace).</translation>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Também exibir fim de linha e documento</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_ru.ts
+++ b/featherpad/data/translations/featherpad_ru.ts
@@ -1512,7 +1512,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Показ строки в конце документа</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_si.ts
+++ b/featherpad/data/translations/featherpad_si.ts
@@ -1536,7 +1536,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_sk_SK.ts
+++ b/featherpad/data/translations/featherpad_sk_SK.ts
@@ -1537,7 +1537,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation></translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_sl.ts
+++ b/featherpad/data/translations/featherpad_sl.ts
@@ -1539,7 +1539,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_sv.ts
+++ b/featherpad/data/translations/featherpad_sv.ts
@@ -1550,7 +1550,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Visa också linje- och dokumentavslutningar</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_tr.ts
+++ b/featherpad/data/translations/featherpad_tr.ts
@@ -1575,7 +1575,7 @@ tipi (Monospace gibi) kullanılıyorsa çizilir.</translation>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>&amp;Satır ve belge sonlarını da göster</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_uk.ts
+++ b/featherpad/data/translations/featherpad_uk.ts
@@ -1561,7 +1561,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>Також показувати лінії закінчення рядків і документів</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_zh_CN.ts
+++ b/featherpad/data/translations/featherpad_zh_CN.ts
@@ -1550,7 +1550,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation>也显示行与文档结尾</translation>
     </message>
     <message>

--- a/featherpad/data/translations/featherpad_zh_TW.ts
+++ b/featherpad/data/translations/featherpad_zh_TW.ts
@@ -1539,7 +1539,7 @@ the editor font has a fixed pitch (like Monospace).</source>
     </message>
     <message>
         <location filename="../../prefDialog.ui" line="657"/>
-        <source>Also show line and document ends</source>
+        <source>Show line and document ends</source>
         <translation></translation>
     </message>
     <message>

--- a/featherpad/prefDialog.ui
+++ b/featherpad/prefDialog.ui
@@ -654,7 +654,7 @@ when the syntax is highlighted.</string>
               <item>
                <widget class="QCheckBox" name="endingsBox">
                 <property name="text">
-                 <string>Also show line and document ends</string>
+                 <string>Show line and document ends</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
Although "Also show line and document ends" option is below the "Show whitespaces" option. But, both are different option and "Also show line and document ends" is not sub-option of "Show whitespaces". Hence removed the word "Also" from the option name.