### PR TITLE
Skip an unnecessary file dialog

### DIFF
--- a/featherpad/fpwin.cpp
+++ b/featherpad/fpwin.cpp
@@ -1328,6 +1328,7 @@ FPwin::DOCSTATE FPwin::savePrompt (int tabIndex, bool noToAll,
     if (tabPage == nullptr) return state;
     TextEdit *textEdit = tabPage->textEdit();
     QString fname = textEdit->getFileName();
+    if (fname.isEmpty() && textEdit->document()->isEmpty()) return state; // Skip asking to create a new empty file
     bool isRemoved (!fname.isEmpty() && !QFile::exists (fname)); // don't check QFileInfo (fname).isFile()
     if (textEdit->document()->isModified() || isRemoved)
     {


### PR DESCRIPTION
Skip save prompt for empty tabs, if this would just create a new empty file. Without this line, the user is asked, if they would like to do so, if a new tab is opened, filled with text and emptied again without the tab being saved as a file in the mean time.