### PR TITLE
Use dictionary encoding for Hunspell words

### DIFF
--- a/featherpad/spellChecker.cpp
+++ b/featherpad/spellChecker.cpp
@@ -23,11 +23,24 @@
 #include <QTextStream>
 #include <QStringList>
 #include <QRegularExpression>
+#include <QStringDecoder>
+#include <QStringEncoder>
 
 #include <hunspell.hxx>
 
 namespace FeatherPad {
 
+static inline QStringConverter::Encoding spellEncoding (const QString &encoding)
+{
+    return encoding.compare ("UTF-8", Qt::CaseInsensitive) == 0
+               ? QStringConverter::Utf8
+           : encoding.compare ("UTF-16", Qt::CaseInsensitive) == 0
+               ? QStringConverter::Utf16
+           : encoding.compare ("UTF-32", Qt::CaseInsensitive) == 0
+               ? QStringConverter::Utf32
+           : QStringConverter::Latin1;
+}
+/*************************/
 SpellChecker::SpellChecker (const QString& dictionaryPath, const QString& userDictionary)
 {
     userDictionary_ = userDictionary;
@@ -55,13 +68,7 @@ SpellChecker::SpellChecker (const QString& dictionaryPath, const QString& userDi
         }
         _affixFile.close();
     }
-    encoder_ = QStringEncoder (encoding.compare ("UTF-8", Qt::CaseInsensitive) == 0 ?
-                                   QStringConverter::Utf8
-                               : encoding.compare ("UTF-16", Qt::CaseInsensitive) == 0 ?
-                                   QStringConverter::Utf16
-                               : encoding.compare ("UTF-32", Qt::CaseInsensitive) == 0 ?
-                                   QStringConverter::Utf32
-                               : QStringConverter::Latin1);
+    encoding_ = spellEncoding (encoding);
 
     if (!userDictionary_.isEmpty())
     {
@@ -83,22 +90,34 @@ SpellChecker::~SpellChecker()
 /*************************/
 bool SpellChecker::spell (const QString& word)
 {
-    return hunspell_->spell (word.toStdString());
+    return hunspell_->spell (encodedWord (word));
 }
 /*************************/
 QStringList SpellChecker::suggest (const QString& word)
 {
-    const std::vector<std::string> strSuggestions = hunspell_->suggest (word.toStdString());
+    const std::vector<std::string> strSuggestions = hunspell_->suggest (encodedWord (word));
     QStringList suggestions;
     for (const auto &str : strSuggestions)
-        suggestions << QString::fromStdString (str);
+        suggestions << decodedWord (str);
     return suggestions;
 }
 /*************************/
 void SpellChecker::ignoreWord (const QString& word)
 {
-    QByteArray b = encoder_.encode (word);
-    hunspell_->add (b.toStdString());
+    hunspell_->add (encodedWord (word));
+}
+/*************************/
+std::string SpellChecker::encodedWord (const QString &word) const
+{
+    QStringEncoder encoder (encoding_);
+    const QByteArray b = encoder.encode (word);
+    return std::string (b.constData(), static_cast<size_t>(b.size()));
+}
+/*************************/
+QString SpellChecker::decodedWord (const std::string &word) const
+{
+    QStringDecoder decoder (encoding_);
+    return decoder.decode (QByteArray (word.data(), static_cast<qsizetype>(word.size())));
 }
 /*************************/
 void SpellChecker::addToUserWordlist (const QString& word)

--- a/featherpad/spellChecker.h
+++ b/featherpad/spellChecker.h
@@ -22,7 +22,8 @@
 
 #include <QString>
 #include <QHash>
-#include <QStringEncoder>
+#include <QStringConverter>
+#include <string>
 
 class Hunspell;
 
@@ -46,9 +47,12 @@ public:
     }
 
 private:
+    std::string encodedWord (const QString &word) const;
+    QString decodedWord (const std::string &word) const;
+
     Hunspell *hunspell_;
     QString userDictionary_;
-    QStringEncoder encoder_;
+    QStringConverter::Encoding encoding_;
     QHash<QString, QString> corrections_;
 };
 


### PR DESCRIPTION
Use dictionary encoding for Hunspell words

FeatherPad already reads the Hunspell dictionary encoding from the .aff file, but spell() and suggest() still passed QString::toStdString() directly to Hunspell. That sends UTF-8 bytes regardless of the dictionary encoding, so non-UTF-8 dictionaries can reject correctly spelled words.

This patch stores the detected dictionary encoding and uses it consistently when passing words to Hunspell. Suggestions are decoded with the same encoding before being shown in the UI.

Demo with a minimal ISO8859-1 Hunspell dictionary containing the word “café”:
<img width="2872" height="1176" alt="hunspell-encoding-before-after-transparent" src="https://github.com/user-attachments/assets/33128a57-f797-44b4-a945-2e2c3361e91e" />
