### PR TITLE
Handle empty lines in spellchecker files

### DIFF
--- a/featherpad/spellChecker.cpp
+++ b/featherpad/spellChecker.cpp
@@ -45,7 +45,8 @@ SpellChecker::SpellChecker (const QString& dictionaryPath, const QString& userDi
         QTextStream stream (&_affixFile);
         QRegularExpression encDetector ("^\\s*SET\\s+([A-Z0-9\\-]+)\\s*", QRegularExpression::CaseInsensitiveOption);
         QRegularExpressionMatch match;
-        for (QString line = stream.readLine(); !line.isEmpty(); line = stream.readLine())
+        QString line;
+        while (stream.readLineInto (&line))
         {
             if (line.indexOf (encDetector, 0, &match) > -1)
             {
@@ -69,8 +70,12 @@ SpellChecker::SpellChecker (const QString& dictionaryPath, const QString& userDi
         if (userDictonaryFile.open (QIODevice::ReadOnly))
         {
             QTextStream stream (&userDictonaryFile);
-            for (QString word = stream.readLine(); !word.isEmpty(); word = stream.readLine())
-                ignoreWord (word);
+            QString word;
+            while (stream.readLineInto (&word))
+            {
+                if (!word.isEmpty())
+                    ignoreWord (word);
+            }
             userDictonaryFile.close();
         }
     }


### PR DESCRIPTION
This fixes spellchecker file parsing so empty lines are not treated as end-of-file.

Previously, both the Hunspell affix file and the user dictionary were read with loops that stopped on the first empty line. As a result:

- an empty line before the SET directive in a .aff file prevented FeatherPad from detecting the dictionary encoding;
- an empty line in the user dictionary caused all following words to be ignored.

The code now reads until the actual end of the stream. Empty user dictionary lines are skipped without stopping the rest of the file from being loaded.