### PR TITLE
Clean up failed script processes

### DIFF
--- a/featherpad/fpwin.cpp
+++ b/featherpad/fpwin.cpp
@@ -1981,8 +1981,20 @@ void FPwin::executeProcess()
 
         QProcess *process = new QProcess (tabPage);
         process->setObjectName (fName); // to put it into the message dialog
-        connect (process, &QProcess::readyReadStandardOutput,this, &FPwin::displayOutput);
-        connect (process, &QProcess::readyReadStandardError,this, &FPwin::displayError);
+        connect (process, &QProcess::readyReadStandardOutput, this, &FPwin::displayOutput);
+        connect (process, &QProcess::readyReadStandardError, this, &FPwin::displayError);
+        connect (process, &QProcess::errorOccurred, this, [this, process] (QProcess::ProcessError error) {
+            if (error == QProcess::FailedToStart)
+            {
+                showWarningBar ("<center><b><big>" + tr ("Cannot start process!") + "</big></b></center>"
+                                + "<center><i>" + process->errorString() + "</i></center>",
+                                15);
+                process->deleteLater();
+            }
+        });
+        /* old-fashioned: connect(process, static_cast<void(QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),... */
+        connect (process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+                 [=](int /*exitCode*/, QProcess::ExitStatus /*exitStatus*/) {process->deleteLater();});
         QString command = config.getExecuteCommand();
         if (!command.isEmpty())
         {
@@ -1997,9 +2009,6 @@ void FPwin::executeProcess()
         }
         else
             process->start (fName, QStringList());
-        /* old-fashioned: connect(process, static_cast<void(QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),... */
-        connect (process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
-                 [=](int /*exitCode*/, QProcess::ExitStatus /*exitStatus*/) {process->deleteLater();});
     }
 }
 /*************************/


### PR DESCRIPTION
This fixes cleanup after a script process fails to start.

FeatherPad allows only one running process per tab by checking for a child QProcess. However, the script QProcess was deleted only from the finished signal. If QProcess::start() failed, for example because the configured command in Preferences did not exist, the QProcess object could remain as a direct child of the tab. After that, trying to run the script again could incorrectly show "Another process is running in this tab!" even though no process was actually running.

This connects QProcess::errorOccurred before starting the process and deletes the process on FailedToStart. It also connects the finished cleanup before start(), so cleanup is installed before the process can emit completion signals.