### PR TITLE
Fix side-pane tooltips for moved tabs

### DIFF
--- a/featherpad/fpwin.cpp
+++ b/featherpad/fpwin.cpp
@@ -5056,7 +5056,7 @@ void FPwin::detachTab()
                                                          : hasFinalTarget ? QIcon (":icons/hasTarget.svg")
                                                                           : QIcon(),
                                                   fname, lw);
-        lw->setToolTip (tooltip);
+        lwi->setToolTip (tooltip);
         dropTarget->sideItems_.insert (lwi, tabPage);
         lw->addItem (lwi);
         lw->setCurrentItem (lwi);
@@ -5317,7 +5317,7 @@ void FPwin::dropTab (const QString& str, QObject *source)
                                                          : hasFinalTarget ? QIcon (":icons/hasTarget.svg")
                                                                           : QIcon(),
                                                   fname, lw);
-        lw->setToolTip (tooltip);
+        lwi->setToolTip (tooltip);
         sideItems_.insert (lwi, tabPage);
         lw->addItem (lwi);
         lw->setCurrentItem (lwi);


### PR DESCRIPTION
Fix side-pane tooltips for moved tabs

When a tab is detached into a new window or dropped into another window, FeatherPad recreates the corresponding side-pane QListWidgetItem. The code preserves the tab tooltip in a local variable, but assigns it to the ListWidget itself instead of the newly created item.

The side pane displays tooltips from the item under the mouse, so the moved item loses its expected tooltip.

This assigns the preserved tooltip to the new ListWidgetItem in both tab-moving paths, matching the normal side-pane item creation path.